### PR TITLE
Add default error message

### DIFF
--- a/pmpro-strong-passwords.php
+++ b/pmpro-strong-passwords.php
@@ -171,7 +171,12 @@ function pmpro_strong_password_check( $pmpro_continue_registration ) {
 			}
 		}
 
-		pmpro_setMessage( __( 'Password Error:', 'pmpro-strong-passwords' ) . ' ' .apply_filters( 'pmprosp_minimum_password_score_message', implode( " ", $suggestions ), $password_strength ), 'pmpro_error' );
+		// If the suggestions are still empty, add a generic one.
+		if ( empty( $suggestions ) ) {
+			$suggestions[] = __( "Your password is too weak. Please choose a stronger password.", 'pmpro-strong-passwords' );
+		}
+
+		pmpro_setMessage( __( 'Password Error:', 'pmpro-strong-passwords' ) . ' ' . apply_filters( 'pmprosp_minimum_password_score_message', implode( " ", $suggestions ), $password_strength ), 'pmpro_error' );
 		return false;
 	}
 


### PR DESCRIPTION
* ENHANCEMENT: Show a default error message as a fallback when we don't have a suggestion from zxcvbn library. Useful for custom tweaks when you require a different password strength.

Resolves: #59

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?